### PR TITLE
Added temporary patch for WebSocket

### DIFF
--- a/ChatGPT DeMod.user.js
+++ b/ChatGPT DeMod.user.js
@@ -568,7 +568,7 @@ var demod_init = async function() {
             try {
                 const message = JSON.parse(rawMessage)
                 const body = atob(message.data?.body)
-                const modifiedBody = body.replaceAll("\"blocked\": true", "\"blocked\": false")
+                const modifiedBody = body.replaceAll("\"blocked\": true", "\"blocked\": false").replaceAll("\"flagged\": true", "\"flagged\": false")
                 message.data.body = btoa(modifiedBody)
                 return JSON.stringify(message)
             } catch (e) {


### PR DESCRIPTION
Here are some changes I made for myself to avoid issue #38.

It has a problem I've no idea how to workaround, so...

Please merge it **only when** it really saves your time. 🙏    

### Changes
- Skip inner loop of ConversationType.PROMPT when the response data is an url of websocket.
- Replace the value `blocked` flag from `true` to `false` for every websocket message.

### Problems
- Unable to fetch latest conversation for user when the message is blocked, due to unable to intercept websocket with asynchronous function.

### Cause of the issue #38
- ChatGPT responsing conversation with only an url of websocket

![image](https://github.com/4as/ChatGPT-DeMod/assets/1002511/bbb17c42-4db6-466d-8859-c6bc1fc42e6c)
