### PR TITLE
Change domain name

### DIFF
--- a/ChatGPT DeMod.user.js
+++ b/ChatGPT DeMod.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         ChatGPT DeMod
 // @namespace    pl.4as.chatgpt
-// @version      4.1
+// @version      4.2
 // @description  Hides moderation results during conversations with ChatGPT
 // @author       4as
 // @match        *://chatgpt.com/*

--- a/ChatGPT DeMod.user.js
+++ b/ChatGPT DeMod.user.js
@@ -4,7 +4,7 @@
 // @version      4.1
 // @description  Hides moderation results during conversations with ChatGPT
 // @author       4as
-// @match        *://chat.openai.com/*
+// @match        *://chatgpt.com/*
 // @icon         data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
 // @downloadURL  https://raw.githubusercontent.com/4as/ChatGPT-DeMod/main/ChatGPT%20DeMod.user.js
 // @updateURL    https://raw.githubusercontent.com/4as/ChatGPT-DeMod/main/ChatGPT%20DeMod.user.js


### PR DESCRIPTION
The domain name for chatgpt has just changed from chat.openai.com to chatgpt.com.

The login page is still chat.openai.com, but after login, you are redirected.

This resolves #45 

